### PR TITLE
contentType to Message and custom codec support

### DIFF
--- a/src/features/core/hooks/useStartClient.ts
+++ b/src/features/core/hooks/useStartClient.ts
@@ -4,13 +4,19 @@ import { XmtpClient } from '../lib';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useWorkerClient } from './useWorkerClient';
 import { Signer } from '@ethersproject/abstract-signer';
+import { ContentCodec } from '@relaycc/xmtp-js';
 
 export interface UseStartClientProps {
   onSuccess?: (client: XmtpClient | null) => unknown;
   onError?: (error: unknown) => unknown;
+  codecs?: ContentCodec<unknown>[];
 }
 
-export const useStartClient = ({ onSuccess, onError }: UseStartClientProps) => {
+export const useStartClient = ({
+  onSuccess,
+  onError,
+  codecs,
+}: UseStartClientProps) => {
   const queryClient = useQueryClient({ context: QueryContext });
   const worker = useWorkerClient();
 
@@ -27,6 +33,7 @@ export const useStartClient = ({ onSuccess, onError }: UseStartClientProps) => {
           'useStartClient mutationFn, workerClient isReady = false'
         );
       } else {
+        await worker.addCodec(...(codecs ?? []));
         return await worker.startClient(wallet, opts);
       }
     },

--- a/src/features/core/lib/xmtp-worker-client.ts
+++ b/src/features/core/lib/xmtp-worker-client.ts
@@ -2,6 +2,7 @@ import { wrap, Remote, proxy } from 'comlink';
 import { IXmtpWorker, TargetOpts } from './xmtp-worker-interface';
 import { Wallet, ClientOptions, isIdentityWallet } from '../../../lib';
 import { XmtpClient } from './xmtp-client';
+import { ContentCodec } from '@relaycc/xmtp-js';
 
 type XmtpWorkerClass = IXmtpWorker & {
   new (): IXmtpWorker;
@@ -32,6 +33,11 @@ export class XmtpWorkerClient {
   public async createIdentity() {
     const worker = await this.worker;
     return worker.createIdentity();
+  }
+
+  public async addCodec(...codecs: ContentCodec<unknown>[]): Promise<void> {
+    const worker = await this.worker;
+    await worker.addCodec(...codecs);
   }
 
   public async startClient(

--- a/src/features/core/lib/xmtp-worker-interface.ts
+++ b/src/features/core/lib/xmtp-worker-interface.ts
@@ -9,6 +9,7 @@ import {
   ClientOptions,
   EthAddress,
 } from '../../../lib';
+import { ContentCodec } from '@relaycc/xmtp-js';
 
 /* We define the XmtpWorker's interface in a separate file so that we can avoid
  * exporting anything from the XmtpWorker file. Adding exports to the WebWorker
@@ -20,6 +21,7 @@ export interface TargetOpts {
 }
 
 export interface IXmtpWorker {
+  addCodec(...codecs: ContentCodec<unknown>[]): void;
   createIdentity(): Promise<IdentityWallet | null>;
   startClient(
     wallet: Wallet,

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -1,4 +1,4 @@
-import { DecodedMessage } from '@relaycc/xmtp-js';
+import { ContentTypeId, DecodedMessage } from '@relaycc/xmtp-js';
 import { EthAddress, isEthAddress } from './eth';
 import {
   Conversation,
@@ -12,6 +12,7 @@ export interface Message {
   senderAddress: EthAddress;
   sent: Date;
   content: unknown;
+  contentType: ContentTypeId;
 }
 
 export const isMessage = (value: unknown): value is Message => {
@@ -47,6 +48,7 @@ export const fromXmtpMessage = (message: DecodedMessage): Message => {
     })(),
     sent: message.sent,
     content: message.content,
+    contentType: message.contentType,
   };
 };
 


### PR DESCRIPTION
**Note: Pull requests which don't include the minimum details specified
in this template will probably be closed out-of-hand.**

# Issue Link or Description (the "what" and "why")

For custom message rendering we need two things for the clients;
 - add content types to a message (so we know what we should render)
 - and a codec with the given content type (so we know how to decode the message content)

I added the contentType to the Message interface, that was a no-brainer.

I also added the codecs list to the useStartClient as an optional parameter.


# Implementation Details (the "how")

The content type part is inside the Message file, it is just 2 lines, I really just exposed a parameter.

The `xmtp-worker` class get a new private field named `codecs` preloaded with the original `CODECS` list. I use the new `this.codecs` instead of the `CODECS` list. The class get a new function `addCodecs` which will check if the newly added codecs are already satisfied, and if not adds them to the codecs list. This function also warns the user if there are already started connections without the newly added codecs (maybe a rejoin logic could be implemented here, but I hope this will be not a common case, also forcing rejoins could lead to other problems so I just print a warn).

One thing could be faulty with the add logic, the major-minor version checking. Maybe we should just add every codec that is not exactly the same as the already added ones. Probably we should modify that part in the future.

All of the other codes are basically just exposing parameters, and adding functions to interfaces.

# How the changeset was tested

Not tested yet, should not broke anything.
